### PR TITLE
Adding the use of acronyms and automatic list of acronyms.

### DIFF
--- a/report.tex
+++ b/report.tex
@@ -20,6 +20,12 @@
 \usepackage{algpseudocode}
 \usepackage{siunitx}
 \usepackage[framemethod=TikZ]{mdframed}
+\usepackage[acronym,automake]{glossaries-extra}
+
+\setabbreviationstyle[acronym]{long-short}
+\subfile{subfiles/acronyms}
+\makeglossaries{}
+
 
 \mdfdefinestyle{frameStyle}{%
 	roundcorner=5pt,
@@ -76,6 +82,7 @@ Write up to three keywords about your work.
 
 \bibliographystyle{IEEEtran}
 \bibliography{references}
+\printglossary[type=\acronymtype]
 
 \subfile{subfiles/acknowledgement}
 \subfile{subfiles/statement_of_originality}

--- a/subfiles/acronyms.tex
+++ b/subfiles/acronyms.tex
@@ -1,0 +1,2 @@
+% example of how to set an acronym that you will call using \Gls{rnd}, \Glspl{rnd}, \gls{rnd}, \glspl{rnd}
+\newacronym{rnd}{R\&D}{research and development}

--- a/subfiles/introduction.tex
+++ b/subfiles/introduction.tex
@@ -5,7 +5,7 @@
     \section{Introduction}
     \label{sec:introduction}
 
-    This is a template for MAS R\&D projects, based on \emph{IEEETran}.
+    This is a template for MAS \gls{rnd} projects, based on \emph{IEEETran}.
     Here are some preliminaries about some common things you need to do to use the template:
     \begin{itemize}
         \item Add your references to the file \emph{references.bib} and cite them as Mustermann and Smith \cite{referenceexample} (if there are more than three authors, cite as Mustermann et al. \cite{referenceexample}).


### PR DESCRIPTION
This pull request facilitates the use of acronyms using `\usepackage[acronym,automake]{glossaries-extra}`.

Assuming my acronym definition is `\newacronym{rnd}{R\&D}{research and development}`
This setup automatically place the long form `research and development (R&D)` only the first time the acronym is called using `\gls{rnd}`.
All the successive calls of `\gls{rnd}` will results as `R&D` in the text.

It is possible to choose to use the capitalized version `\Gls{rnd}`, the plural version `\glspl{rnd}` or the capitalized-plural version `\Glspl{rnd}`.

At the end of the report, an automatic list of the acronyms is generated.
```
R&D research and development 1
```
which has the following structure: short-form, long-form,  list of pages where each abreviation is used.
